### PR TITLE
Removed duplicate word in document

### DIFF
--- a/draft-spaghetti-grow-bcp-ext-comms.xml
+++ b/draft-spaghetti-grow-bcp-ext-comms.xml
@@ -60,7 +60,7 @@
             <t>
                 This document outlines a recommendation to the Internet operational community to discourage the use of BGP Extended Communities in BGP announcements.
                 It includes guidance for both IP networks and Internet Exchange Points (IXPs).
-                This approach helps ensure the global Internet routing system performance and helps protect Route Server stakeholders against against misconfigurations.
+                This approach helps ensure the global Internet routing system performance and helps protect Route Server stakeholders against misconfigurations.
             </t>
         </section>
 


### PR DESCRIPTION
Removed duplicate 'against' in 'helps protect Route Server stakeholders against against misconfigurations' wording.